### PR TITLE
Allow overwriting the expiration per item

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ module.exports = function (options) {
         if (!err) {
           const result = args.slice(1);
           if (itemMaxAge) {
-            cache.set(key, result, itemMaxAge(result));
+            cache.set(key, result, itemMaxAge.apply(self, parameters.concat(result)));
           } else {
             cache.set(key, result);
           }
@@ -106,7 +106,7 @@ module.exports.sync = function (options) {
 
     const result = load.apply(self, args);
     if (itemMaxAge) {
-      cache.set(key, result, itemMaxAge(result));
+      cache.set(key, result, itemMaxAge.apply(self, args.concat([ result ])));
     } else {
       cache.set(key, result);
     }

--- a/test/lru-memoizer.itemmaxage.test.js
+++ b/test/lru-memoizer.itemmaxage.test.js
@@ -1,0 +1,112 @@
+var memoizer = require('./..');
+var assert = require('chai').assert;
+
+describe('lru-memoizer (itemMaxAge)', function () {
+  var loadTimes = 0, memoized;
+
+  beforeEach(function () {
+    loadTimes = 0;
+  });
+
+  it('should use default behavior if not configured', function (done) {
+    memoized = memoizer({
+      load: function (a, b, callback) {
+        loadTimes++;
+        setTimeout(function () {
+          callback(null, a + b);
+        }, 100);
+      },
+      hash: function (a, b) {
+        return a + '-' + b;
+      },
+      max: 10,
+      maxAge: 500
+    });
+
+    memoized(1,2, function (err, result) {
+      assert.isNull(err);
+      assert.strictEqual(result, 3);
+      assert.strictEqual(loadTimes, 1);
+
+      // Not expired yet.
+      setTimeout(function() {
+        memoized(1,2, function (err, result) {
+          assert.isNull(err);
+          assert.strictEqual(result, 3);
+          assert.strictEqual(loadTimes, 1);
+
+          // Expired, load times will increase.
+          setTimeout(function() {
+            memoized(1,2, function (err, result) {
+              assert.isNull(err);
+              assert.strictEqual(result, 3);
+              assert.strictEqual(loadTimes, 2);
+              done();
+            });
+          }, 200);
+        });
+      }, 400);
+    });
+  });
+
+  it('should overwrite the default behavior if configured', function (done) {
+    var maxAge = 0;
+    memoized = memoizer({
+      load: function (a, b, callback) {
+        loadTimes++;
+        setTimeout(function () {
+          callback(null, a + b);
+        }, 100);
+      },
+      itemMaxAge: function (result) {
+        // In this test, we set the maxAge of the current item to (result*100).
+        // If the result is 3, the max age of this item will be 300.
+        maxAge = result * 100;
+        return maxAge;
+      },
+      hash: function (a, b) {
+        return a + '-' + b;
+      },
+      max: 10,
+      maxAge: 600
+    });
+
+    memoized(1,2, function (err, result) {
+      assert.isNull(err);
+      assert.strictEqual(maxAge, 300);
+      assert.strictEqual(result, 3);
+      assert.strictEqual(loadTimes, 1);
+
+      // Not expired yet after 200 ms, because the expiration is 300
+      setTimeout(function() {
+        memoized(1,2, function (err, result) {
+          assert.isNull(err);
+          assert.strictEqual(maxAge, 300);
+          assert.strictEqual(result, 3);
+          assert.strictEqual(loadTimes, 1);
+
+          // Expired because now we are at 350 ms (even though gloabl expiration has been set to 600)
+          setTimeout(function() {
+            memoized(1,2, function (err, result) {
+              assert.isNull(err);
+              assert.strictEqual(maxAge, 300);
+              assert.strictEqual(result, 3);
+              assert.strictEqual(loadTimes, 2);
+
+              // Expired again, because 350ms have passed again.
+              setTimeout(function() {
+                memoized(1,2, function (err, result) {
+                  assert.isNull(err);
+                  assert.strictEqual(maxAge, 300);
+                  assert.strictEqual(result, 3);
+                  assert.strictEqual(loadTimes, 3);
+                  done();
+                });
+              }, 350);
+            });
+          }, 150);
+        });
+      }, 200);
+    });
+  });
+});

--- a/test/lru-memoizer.itemmaxage.test.js
+++ b/test/lru-memoizer.itemmaxage.test.js
@@ -49,8 +49,8 @@ describe('lru-memoizer (itemMaxAge)', function () {
     });
   });
 
-  it('should overwrite the default behavior if configured', function (done) {
-    var maxAge = 0;
+  it('should return all args and the result in the itemMaxAge function', function (done) {
+    var args;
     memoized = memoizer({
       load: function (a, b, callback) {
         loadTimes++;
@@ -58,7 +58,38 @@ describe('lru-memoizer (itemMaxAge)', function () {
           callback(null, a + b);
         }, 100);
       },
-      itemMaxAge: function (result) {
+      itemMaxAge: function (a, b, result) {
+        args = arguments;
+        return 1000;
+      },
+      hash: function (a, b) {
+        return a + '-' + b;
+      },
+      max: 10,
+      maxAge: 600
+    });
+
+    memoized(1,2, function (err, result) {
+      assert.isNull(err);
+      assert.strictEqual(args[0], 1);
+      assert.strictEqual(args[1], 2);
+      assert.strictEqual(args[2], 3);
+      done();
+    });
+  });
+
+  it('should overwrite the default behavior if configured', function (done) {
+    var maxAge = 0;
+    var lastKey = null;
+    memoized = memoizer({
+      load: function (a, b, callback) {
+        loadTimes++;
+        setTimeout(function () {
+          callback(null, a + b);
+        }, 100);
+      },
+      itemMaxAge: function (a, b, result) {
+        lastKey = a + '-' + b;
         // In this test, we set the maxAge of the current item to (result*100).
         // If the result is 3, the max age of this item will be 300.
         maxAge = result * 100;
@@ -74,6 +105,7 @@ describe('lru-memoizer (itemMaxAge)', function () {
     memoized(1,2, function (err, result) {
       assert.isNull(err);
       assert.strictEqual(maxAge, 300);
+      assert.strictEqual(lastKey, '1-2');
       assert.strictEqual(result, 3);
       assert.strictEqual(loadTimes, 1);
 
@@ -82,6 +114,7 @@ describe('lru-memoizer (itemMaxAge)', function () {
         memoized(1,2, function (err, result) {
           assert.isNull(err);
           assert.strictEqual(maxAge, 300);
+          assert.strictEqual(lastKey, '1-2');
           assert.strictEqual(result, 3);
           assert.strictEqual(loadTimes, 1);
 
@@ -90,6 +123,7 @@ describe('lru-memoizer (itemMaxAge)', function () {
             memoized(1,2, function (err, result) {
               assert.isNull(err);
               assert.strictEqual(maxAge, 300);
+              assert.strictEqual(lastKey, '1-2');
               assert.strictEqual(result, 3);
               assert.strictEqual(loadTimes, 2);
 
@@ -98,6 +132,7 @@ describe('lru-memoizer (itemMaxAge)', function () {
                 memoized(1,2, function (err, result) {
                   assert.isNull(err);
                   assert.strictEqual(maxAge, 300);
+                  assert.strictEqual(lastKey, '1-2');
                   assert.strictEqual(result, 3);
                   assert.strictEqual(loadTimes, 3);
                   done();
@@ -108,5 +143,62 @@ describe('lru-memoizer (itemMaxAge)', function () {
         });
       }, 200);
     });
+  });
+
+  it('should overwrite the default behavior if configured (sync)', function (done) {
+    var maxAge = 0;
+    var lastKey = null;
+    memoized = memoizer.sync({
+      load: function (a, b) {
+        loadTimes++;
+        return a + b;
+      },
+      itemMaxAge: function (a, b, result) {
+        lastKey = a + '-' + b;
+        // In this test, we set the maxAge of the current item to (result*100).
+        // If the result is 3, the max age of this item will be 300.
+        maxAge = result * 100;
+        return maxAge;
+      },
+      hash: function (a, b) {
+        return a + '-' + b;
+      },
+      max: 10,
+      maxAge: 600
+    });
+
+    var result = memoized(1, 2);
+    assert.strictEqual(maxAge, 300);
+    assert.strictEqual(lastKey, '1-2');
+    assert.strictEqual(result, 3);
+    assert.strictEqual(loadTimes, 1);
+
+    // Not expired yet after 200 ms, because the expiration is 300
+    setTimeout(function() {
+      result = memoized(1, 2);
+      assert.strictEqual(maxAge, 300);
+      assert.strictEqual(lastKey, '1-2');
+      assert.strictEqual(result, 3);
+      assert.strictEqual(loadTimes, 1);
+
+      // Expired because now we are at 350 ms (even though gloabl expiration has been set to 600)
+      setTimeout(function() {
+        result = memoized(1,2);
+        assert.strictEqual(maxAge, 300);
+        assert.strictEqual(lastKey, '1-2');
+        assert.strictEqual(result, 3);
+        assert.strictEqual(loadTimes, 2);
+
+          // Expired again, because 350ms have passed again.
+          setTimeout(function() {
+            result = memoized(1,2);
+            assert.strictEqual(maxAge, 300);
+            assert.strictEqual(lastKey, '1-2');
+            assert.strictEqual(result, 3);
+            assert.strictEqual(loadTimes, 3);
+            done();
+          }, 350);
+      }, 150);
+    }, 200);
   });
 });


### PR DESCRIPTION
Some items (like a token) might tell you how long they are valid. In that case it would be useful to bubble up that expiration to the cache.
