### PR TITLE
Use most recent non-breaking 4.X lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "lock": "~0.1.2",
-    "lodash": "~4.5.1",
+    "lodash": "^4.17.4",
     "lru-cache": "~4.0.0",
     "very-fast-args": "^1.1.0"
   },


### PR DESCRIPTION
If this module uses a `^` for the lodash dependency, lodash can be flattened in the `npm_modules` directory of consuming packages.