### PR TITLE
Reduced the lodash dependency to include only the lodash functions required for the logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,14 @@
-const LRU        = require('lru-cache');
-const _          = require('lodash');
-const lru_params = [ 'max', 'maxAge', 'length', 'dispose', 'stale' ];
-const deepFreeze = require('./lib/freeze');
-const vfs        = require('very-fast-args');
+const LRU         = require('lru-cache');
+const l_pick      = require('lodash.pick');
+const l_toArray   = require('lodash.toarray');
+const l_extend    = require('lodash.assignin');
+const l_cloneDeep = require('lodash.clonedeep');
+const lru_params  = [ 'max', 'maxAge', 'length', 'dispose', 'stale' ];
+const deepFreeze  = require('./lib/freeze');
+const vfs         = require('very-fast-args');
 
 module.exports = function (options) {
-  const cache      = new LRU(_.pick(options, lru_params));
+  const cache      = new LRU(l_pick(options, lru_params));
   const load       = options.load;
   const hash       = options.hash;
   const bypass     = options.bypass;
@@ -15,7 +18,7 @@ module.exports = function (options) {
   const loading    = new Map();
 
   if (options.disable) {
-      _.extend(load, { del }, options);
+      l_extend(load, { del }, options);
     return load;
   }
 
@@ -47,7 +50,7 @@ module.exports = function (options) {
 
     if (fromCache) {
       if (clone) {
-        return callback.apply(null, [null].concat(fromCache).map(_.cloneDeep));
+        return callback.apply(null, [null].concat(fromCache).map(l_cloneDeep));
       }
       return callback.apply(null, [null].concat(fromCache));
     }
@@ -76,7 +79,7 @@ module.exports = function (options) {
         loading.delete(key);
         waiting.forEach(function (callback) {
           if (clone) {
-            return callback.apply(null, args.map(_.cloneDeep));
+            return callback.apply(null, args.map(l_cloneDeep));
           }
           callback.apply(null, args);
         });
@@ -90,14 +93,14 @@ module.exports = function (options) {
 
   result.keys = cache.keys.bind(cache);
 
-  _.extend(result, { del }, options);
+  l_extend(result, { del }, options);
 
   return result;
 };
 
 
 module.exports.sync = function (options) {
-  const cache = new LRU(_.pick(options, lru_params));
+  const cache = new LRU(l_pick(options, lru_params));
   const load = options.load;
   const hash = options.hash;
   const disable = options.disable;
@@ -110,7 +113,7 @@ module.exports.sync = function (options) {
   }
 
   const result = function () {
-    var args = _.toArray(arguments);
+    var args = l_toArray(arguments);
 
     if (bypass && bypass.apply(self, arguments)) {
       return load.apply(self, arguments);

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "mocha": "~2.2.5",
-    "lodash": "^4.17.4"
+    "lodash.noop": "^3.0.1",
+    "mocha": "~2.2.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,12 +18,16 @@
   },
   "dependencies": {
     "lock": "~0.1.2",
-    "lodash": "^4.17.4",
+    "lodash.assignin": "^4.2.0",
+    "lodash.clonedeep": "^4.5.0",
+    "lodash.pick": "^4.4.0",
+    "lodash.toarray": "^4.4.0",
     "lru-cache": "~4.0.0",
     "very-fast-args": "^1.1.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "mocha": "~2.2.5"
+    "mocha": "~2.2.5",
+    "lodash": "^4.17.4"
   }
 }

--- a/test/lru-memoizer.lock.test.js
+++ b/test/lru-memoizer.lock.test.js
@@ -1,6 +1,6 @@
 const memoizer = require('./..');
 const assert   = require('chai').assert;
-const _        = require('lodash');
+const l_noop   = require('lodash.noop');
 
 describe('lru-simultaneos calls', function () {
   var loadTimes = 0, memoized;
@@ -23,8 +23,8 @@ describe('lru-simultaneos calls', function () {
   });
 
   it('should call once', function (done) {
-    memoized(1, 2, _.noop);
-    memoized(1, 2, _.noop);
+    memoized(1, 2, l_noop);
+    memoized(1, 2, l_noop);
     memoized(1, 2, function (err, result) {
       if (err) { return done(err); }
       assert.strictEqual(loadTimes, 1);


### PR DESCRIPTION
I am trying to reference the jwks-rsa package in an AWS Lambda @ Edge function that is limited to 1 MB in size when compressed.  The jwks-rsa package, in turn, was referencing this package.  In an attempt to reduce the overall package size, I have refined the sizable lodash dependency to include only the modularized functions this package needs.  No functionality changes were made.