### PR TITLE
Remove es2015 shorthand properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = function (options) {
   const loading    = new Map();
 
   if (options.disable) {
-      _.extend(load, { del }, options);
+      _.extend(load, { del: del }, options);
     return load;
   }
 
@@ -90,7 +90,7 @@ module.exports = function (options) {
 
   result.keys = cache.keys.bind(cache);
 
-  _.extend(result, { del }, options);
+  _.extend(result, { del: del }, options);
 
   return result;
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lru-memoizer",
   "description": "Memoize functions results using an lru-cache.",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "author": "José F. Romaniello <jfromaniello@gmail.com> (http://joseoncode.com)",
   "types": "./types/lru-memoizer.d.ts",
   "repository": {


### PR DESCRIPTION
Using shorthand properties makes it difficult for including in browser-based projects that don't support shorthand properties (<cough cough>ie 11)