### PR TITLE
Emit on cache event

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,6 +123,8 @@ module.exports.sync = function (options) {
   const bypass = options.bypass;
   const self = this;
   const itemMaxAge = options.itemMaxAge;
+  const onHit      = options.onHit;
+  const onMiss     = options.onMiss;
 
   if (disable) {
     return load;
@@ -132,6 +134,10 @@ module.exports.sync = function (options) {
     var args = _.toArray(arguments);
 
     if (bypass && bypass.apply(self, arguments)) {
+      if (onMiss) {
+        onMiss.apply(self, parameters);
+      }
+
       return load.apply(self, arguments);
     }
 
@@ -140,7 +146,15 @@ module.exports.sync = function (options) {
     var fromCache = cache.get(key);
 
     if (fromCache) {
+      if (onHit) {
+        onHit.apply(self, parameters);
+      }
+
       return fromCache;
+    }
+
+    if (onMiss) {
+      onMiss.apply(self, parameters);
     }
 
     const result = load.apply(self, args);

--- a/index.js
+++ b/index.js
@@ -13,6 +13,9 @@ module.exports = function (options) {
   const freeze     = options.freeze;
   const clone      = options.clone;
   const loading    = new Map();
+  const onHit      = options.onHit;
+  const onMiss     = options.onMiss;
+  const onQueue    = options.onQueue;
 
   if (options.disable) {
       _.extend(load, { del }, options);
@@ -33,6 +36,10 @@ module.exports = function (options) {
     var key;
 
     if (bypass && bypass.apply(self, parameters)) {
+      if (onMiss) {
+        onMiss.apply(self, parameters);
+      }
+
       return load.apply(self, args);
     }
 
@@ -46,6 +53,10 @@ module.exports = function (options) {
     var fromCache = cache.get(key);
 
     if (fromCache) {
+      if (onHit) {
+        onHit.apply(self, parameters);
+      }
+
       if (clone) {
         return callback.apply(null, [null].concat(fromCache).map(_.cloneDeep));
       }
@@ -53,6 +64,10 @@ module.exports = function (options) {
     }
 
     if (!loading.get(key)) {
+      if (onMiss) {
+        onMiss.apply(self, parameters);
+      }
+
       loading.set(key, []);
 
       load.apply(self, parameters.concat(function (err) {
@@ -84,6 +99,10 @@ module.exports = function (options) {
 
       }));
     } else {
+      if (onQueue) {
+        onQueue.apply(self, parameters);
+      }
+
       loading.get(key).push(callback);
     }
   };

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "mocha": "~2.2.5"
+    "mocha": "~2.2.5",
+    "sinon": "^7.3.2"
   }
 }

--- a/test/lru-memoizer.events.test.js
+++ b/test/lru-memoizer.events.test.js
@@ -1,0 +1,133 @@
+const memoizer = require('./..');
+const sinon = require('sinon');
+const assert = require('chai').assert;
+
+describe('lru-memoizer', function () {
+  let memoized;
+  let onMiss, onHit, onQueue;
+
+  beforeEach(function () {
+    loadTimes = 0;
+    onMiss = sinon.stub();
+    onHit = sinon.stub();
+    onQueue = sinon.stub();
+    memoized = memoizer({
+      onMiss,
+      onHit,
+      onQueue,
+      load: function (a, b, bypass, callback) {
+        return setTimeout(function () {
+          if (a === 0) {
+            return callback(new Error('a cant be 0'));
+          }
+          callback(null, a+b);
+        }, 10);
+      },
+      hash: function (a, b) {
+        return a + '-' + b;
+      },
+      bypass: function(a, b, bypass) {
+        return bypass;
+      },
+      max: 10
+    });
+  });
+
+  describe('when the result is not in the cache', () => {
+    beforeEach((done) => {
+      memoized(1, 2, false, done);
+    });
+
+    it('should not call onHit', () => {
+      sinon.assert.notCalled(onHit);
+    });
+
+    it('should not call onQueue', () => {
+      sinon.assert.notCalled(onQueue);
+    });
+
+    it('should call onMiss with the load arguments', () => {
+      sinon.assert.calledOnce(onMiss);
+      sinon.assert.calledWith(onMiss, 1, 2, false);
+    });
+  });
+
+  describe('when the result is in the cache', () => {
+    beforeEach((done) => {
+      memoized(1,2, false, () => {
+        onHit.reset();
+        onMiss.reset();
+        onQueue.reset();
+        memoized(1, 2, false, done);
+      });
+    });
+
+    it('should call onHit with the load arguments', () => {
+      sinon.assert.calledOnce(onHit);
+      sinon.assert.calledWith(onHit, 1, 2, false);
+    });
+
+    it('should not call onQueue', () => {
+      sinon.assert.notCalled(onQueue);
+    });
+
+    it('should not call onMiss', () => {
+      sinon.assert.notCalled(onQueue);
+    });
+  });
+
+  describe('when the cache is by passed', () => {
+    beforeEach((done) => {
+      memoized(1,2, false, () => {
+        onHit.reset();
+        onMiss.reset();
+        onQueue.reset();
+        memoized(1, 2, true, done);
+      });
+    });
+
+    it('should not call onHit', () => {
+      sinon.assert.notCalled(onHit);
+    });
+
+    it('should not call onQueue', () => {
+      sinon.assert.notCalled(onQueue);
+    });
+
+    it('should call onMiss with the load arguments', () => {
+      sinon.assert.calledOnce(onMiss);
+      sinon.assert.calledWith(onMiss, 1, 2, true);
+    });
+  });
+
+  describe('when the result is pending', () => {
+    beforeEach((done) => {
+      let pending = 2;
+      function onDone() {
+        pending -= 1;
+        if (pending === 0) {
+          done();
+        }
+      }
+      memoized(1, 2, false, onDone);
+      onHit.reset();
+      onMiss.reset();
+      onQueue.reset();
+      memoized(1, 2, false, onDone);
+    });
+
+    it('should not call onHit', () => {
+      sinon.assert.notCalled(onHit);
+    });
+
+    it('should call onQueue with the load arguments', () => {
+      sinon.assert.calledOnce(onQueue);
+      sinon.assert.calledWith(onQueue, 1, 2, false);
+    });
+
+    it('should not call onMiss', () => {
+      sinon.assert.notCalled(onMiss);
+    });
+  });
+});
+

--- a/test/lru-memoizer.sync.events.test.js
+++ b/test/lru-memoizer.sync.events.test.js
@@ -1,7 +1,7 @@
 const memoizer = require('./..');
 const sinon = require('sinon');
 
-describe('lru-memoizer (events)', function () {
+describe('lru-memoizer sync (events)', function () {
   let memoized;
   let onMiss, onHit, onQueue;
 
@@ -10,16 +10,11 @@ describe('lru-memoizer (events)', function () {
     onMiss = sinon.stub();
     onHit = sinon.stub();
     onQueue = sinon.stub();
-    memoized = memoizer({
-      load: function (a, b, bypass, callback) {
-        return setTimeout(function () {
-          if (a === 0) {
-            return callback(new Error('a cant be 0'));
-          }
-          callback(null, a+b);
-        }, 10);
+    memoized = memoizer.sync({
+      load: function (a, b, bypass) {
+        return a + b;
       },
-      hash: function (a, b) {
+      hash: function (a, b, bypass) {
         return a + '-' + b;
       },
       bypass: function(a, b, bypass) {
@@ -33,8 +28,8 @@ describe('lru-memoizer (events)', function () {
   });
 
   describe('when the result is not in the cache', () => {
-    beforeEach((done) => {
-      memoized(1, 2, false, done);
+    beforeEach(() => {
+      memoized(1, 2, false);
     });
 
     it('should not call onHit', () => {
@@ -52,13 +47,12 @@ describe('lru-memoizer (events)', function () {
   });
 
   describe('when the result is in the cache', () => {
-    beforeEach((done) => {
-      memoized(1,2, false, () => {
-        onHit.reset();
-        onMiss.reset();
-        onQueue.reset();
-        memoized(1, 2, false, done);
-      });
+    beforeEach(() => {
+      memoized(1,2, false);
+      onHit.reset();
+      onMiss.reset();
+      onQueue.reset();
+      memoized(1, 2, false);
     });
 
     it('should call onHit with the load arguments', () => {
@@ -76,13 +70,12 @@ describe('lru-memoizer (events)', function () {
   });
 
   describe('when the cache is by passed', () => {
-    beforeEach((done) => {
-      memoized(1,2, false, () => {
-        onHit.reset();
-        onMiss.reset();
-        onQueue.reset();
-        memoized(1, 2, true, done);
-      });
+    beforeEach(() => {
+      memoized(1,2, false);
+      onHit.reset();
+      onMiss.reset();
+      onQueue.reset();
+      memoized(1, 2, true);
     });
 
     it('should not call onHit', () => {
@@ -96,36 +89,6 @@ describe('lru-memoizer (events)', function () {
     it('should call onMiss with the load arguments', () => {
       sinon.assert.calledOnce(onMiss);
       sinon.assert.calledWith(onMiss, 1, 2, true);
-    });
-  });
-
-  describe('when the result is pending', () => {
-    beforeEach((done) => {
-      let pending = 2;
-      function onDone() {
-        pending -= 1;
-        if (pending === 0) {
-          done();
-        }
-      }
-      memoized(1, 2, false, onDone);
-      onHit.reset();
-      onMiss.reset();
-      onQueue.reset();
-      memoized(1, 2, false, onDone);
-    });
-
-    it('should not call onHit', () => {
-      sinon.assert.notCalled(onHit);
-    });
-
-    it('should call onQueue with the load arguments', () => {
-      sinon.assert.calledOnce(onQueue);
-      sinon.assert.calledWith(onQueue, 1, 2, false);
-    });
-
-    it('should not call onMiss', () => {
-      sinon.assert.notCalled(onMiss);
     });
   });
 });

--- a/types/lru-memoizer.d.ts
+++ b/types/lru-memoizer.d.ts
@@ -1,4 +1,5 @@
 declare module 'lru-memoizer' {
+    type Listener = (...args: any[]) => void;
     type INodeStyleCallBack<SuccessArg> = (
         err: NodeJS.ErrnoException,
         result?: SuccessArg
@@ -27,6 +28,9 @@ declare module 'lru-memoizer' {
             cb: INodeStyleCallBack<TResult>
         ): void;
         keys: () => string[];
+        on(event: 'hit', handler: Listener): void;
+        on(event: 'miss', handler: Listener): void;
+        on(event: 'queue', handler: Listener): void;
     }
 
     interface IMemoizedSync<TResult> {
@@ -50,6 +54,8 @@ declare module 'lru-memoizer' {
             arg6: T6
         ): TResult;
         keys: () => string[];
+        on(event: 'hit', handler: Listener): void;
+        on(event: 'miss', handler: Listener): void;
     }
 
     interface IMemoizableFunction<TResult> {


### PR DESCRIPTION
Emit event on hit/miss/queue. 

This makes it possible to instrument the memoizer to track caching performance.