### PR TITLE
fix: Adds license field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "lodash.clonedeep": "^4.5.0",
     "lru-cache": "~4.0.0"
   },
+  "license":"MIT",
   "devDependencies": {
     "@types/lodash.clonedeep": "^4.5.6",
     "@types/lru-cache": "^5.1.0",


### PR DESCRIPTION
Hi,
I've added the license field in package.json. Due to the missing field the npm package is missing the license field too.
I've added this because our company has an internal license checker on build pipeline and I can't get through that without a valid license field.
I haven't incremented the version number, as I am unaware of whether you would want to increment it or not.

Thanks