### PR TITLE
Expire pending loads

### DIFF
--- a/src/async.ts
+++ b/src/async.ts
@@ -173,15 +173,16 @@ function asyncMemoizer<T1, T2, T3, T4, T5, T6, TResult>(
 
     emit('miss', ...parameters);
 
+    const started = Date.now();
+
     // no pending request or not resolved before expiration
     // create a new queue and invoke load
     const queue = [ callback ];
     loading.set(key, {
       queue,
-      expiresAt: Date.now() + queueMaxAge
+      expiresAt: started + queueMaxAge
     });
 
-    const started = Date.now();
     const loadHandler = (...args: any[]) => {
       const err = args[0];
       if (!err) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -83,18 +83,18 @@ export interface IBypassFunction<T1, T2, T3, T4, T5, T6> {
 }
 
 export interface IMaxAgeFunction<T1, T2, T3, T4, T5, T6, TResult> {
-  (res: TResult): boolean;
-  (arg1: T1, res: TResult): boolean;
-  (arg1: T1, arg2: T2, res: TResult): boolean;
-  (arg1: T1, arg2: T2, arg3: T3, res: TResult): boolean;
-  (arg1: T1, arg2: T2, arg3: T3, arg4: T4, res: TResult): boolean;
+  (res: TResult): number;
+  (arg1: T1, res: TResult): number;
+  (arg1: T1, arg2: T2, res: TResult): number;
+  (arg1: T1, arg2: T2, arg3: T3, res: TResult): number;
+  (arg1: T1, arg2: T2, arg3: T3, arg4: T4, res: TResult): number;
   (
       arg1: T1,
       arg2: T2,
       arg3: T3,
       arg4: T4,
       arg5: T5,
-      res: TResult): boolean;
+      res: TResult): number;
   (
       arg1: T1,
       arg2: T2,
@@ -102,7 +102,10 @@ export interface IMaxAgeFunction<T1, T2, T3, T4, T5, T6, TResult> {
       arg4: T4,
       arg5: T5,
       arg6: T6,
-      res: TResult): boolean;
+      res: TResult): number;
+  (
+    ...rest: any[]
+  ): number;
 }
 
 export interface IParamsBase<T1, T2, T3, T4, T5, T6, TResult> extends LRU.Options<string, any>  {
@@ -136,4 +139,11 @@ export interface IParamsBase<T1, T2, T3, T4, T5, T6, TResult> extends LRU.Option
    * Disable the cache and executes the load logic directly.
    */
   disable?: boolean;
+
+  /**
+   * Do not queue requests if initial call is more than `queueMaxAge` milliseconds old.
+   * Instead, invoke `load` again and create a new queue.
+   * Defaults to 1000ms.
+   */
+  queueMaxAge?: number;
 }

--- a/test/lru-memoizer.clone.test.js
+++ b/test/lru-memoizer.clone.test.js
@@ -10,7 +10,7 @@ describe('lru-memoizer (clone)', function () {
     memoized = memoizer({
       load: function (key, callback) {
         loadTimes++;
-        callback(null, { foo: 'bar' , buffer: new Buffer('1234') });
+        callback(null, { foo: 'bar' , buffer: Buffer.from('1234') });
       },
       hash: function (key) {
         return key;

--- a/test/lru-memoizer.queumaxage.test.js
+++ b/test/lru-memoizer.queumaxage.test.js
@@ -1,0 +1,110 @@
+var memoizer = require('./..');
+var assert = require('chai').assert;
+
+describe('lru-memoizer (queueMaxAge)', function () {
+  var loadTimes = 0, memoized;
+
+  beforeEach(function () {
+    loadTimes = 0;
+  });
+
+  function observer() {
+    const listeners = [];
+    return {
+      listen(listener) {
+        listeners.push(listener);
+      },
+      trigger() {
+        listeners.forEach(listener => listener());
+      }
+    }
+  }
+
+  it('should create a new queue once expired', function (done) {
+    memoized = memoizer({
+      load: function (a, b, onResolve, callback) {
+        loadTimes++;
+        onResolve(() => callback(null, a + b));
+      },
+      queueMaxAge: 10,
+      hash: function (a, b) {
+        return a + '-' + b;
+      }
+    });
+
+    const observer1 = observer();
+    const observer2 = observer();
+    const observer3 = observer();
+    const resolved = [];
+
+    memoized(1, 2, observer1.listen, function (err, result) {
+      assert.isNull(err);
+      assert.strictEqual(result, 3);
+      resolved.push('A');
+    });
+
+    assert.strictEqual(loadTimes, 1);
+
+    memoized(1, 2, assert.fail, function (err, result) {
+      assert.isNull(err);
+      assert.strictEqual(result, 3);
+      resolved.push('B');
+    });
+
+    assert.strictEqual(loadTimes, 1);
+
+    setTimeout(() => {
+      // previous queue expired, this calls will be added to a new queue.
+      memoized(1, 2, observer2.listen, function (err, result) {
+        assert.isNull(err);
+        assert.strictEqual(result, 3);
+        resolved.push('C');
+      });
+
+      memoized(1, 2, assert.fail, function (err, result) {
+        assert.isNull(err);
+        assert.strictEqual(result, 3);
+        resolved.push('D');
+      });
+
+      // only one new invocation to load
+      assert.strictEqual(loadTimes, 2);
+
+      setTimeout(() => {
+        // second queue expired, this calls will be added to a third queue.
+        memoized(1, 2, observer3.listen, function (err, result) {
+          assert.isNull(err);
+          assert.strictEqual(result, 3);
+          resolved.push('E');
+        });
+
+        memoized(1, 2, assert.fail.listen, function (err, result) {
+          assert.isNull(err);
+          assert.strictEqual(result, 3);
+          resolved.push('F');
+        });
+
+        assert.strictEqual(loadTimes, 3);
+
+        observer1.trigger();
+        setImmediate(() => {
+          // first queue was resolved
+          assert.deepEqual(['A', 'B'], resolved);
+
+          observer3.trigger();
+          setImmediate(() => {
+            // third queue was resolved
+            assert.deepEqual(['A', 'B', 'E', 'F'], resolved);
+
+            observer2.trigger();
+            setImmediate(() => {
+              // second queue was resolved
+              assert.deepEqual(['A', 'B', 'E', 'F', 'C', 'D'], resolved);
+              done();
+            });
+          });
+        });
+      }, 100);
+    }, 100);
+  });
+});


### PR DESCRIPTION
In the current implementation, when a `load` is requested but not yet resolved, new requests for the same key will get queued in the queue stored on the `loading` map.

If an error causes the `load` request to never resolve, all future requests for that key will keep being queued, never resolving, and incrementing memory forever, even if a _new_ call to `load` would resolve successfully. A `load` call that never resolves _is_ a client error, however, this memoizer implementation can protect itself of this kind of errors by stopping queuing new calls for a `load` request that is taking to long to resolve.

This PR adds this protection by allowing the client to specify a `queueMaxAge` option when building the memoizer (defaults to 1000 ms). 

If when calling the memoized function, a queue created for a `load` request is older than `queueMaxAge`, a new `load` call will be performed instead and a new queue will be created.

If the original `load` request (the whose queue expired) is eventually resolved, all the requests queued for that call will also get resolved. 

However, if the new `load` call is resolved, only requests queued after that new call will be resolved. 