### PR TITLE
fix: better types for simpler use in TS

### DIFF
--- a/src/async.ts
+++ b/src/async.ts
@@ -3,86 +3,117 @@ import { EventEmitter } from 'events';
 import cloneDeep from 'lodash.clonedeep';
 import { deepFreeze } from './freeze';
 import { syncMemoizer } from './sync';
-import { INodeStyleCallBack, ResultBase, IParamsBase} from './util';
+import {
+  INodeStyleCallBack as CB,
+  ResultBase,
+  IParamsBase0,
+  IParamsBase1,
+  IParamsBase2,
+  IParamsBase3,
+  IParamsBase4,
+  IParamsBase5,
+  IParamsBase6,
+  IParamsBasePlus,
+} from './util';
 
 type Callback = (err?: any, ...args: any[]) => void;
 
 type PendingLoad = {
   queue: Callback[];
   expiresAt: number;
+};
+
+export interface IMemoized<T1, T2, T3, T4, T5, T6, TResult> extends ResultBase {
+  (cb: CB<TResult>): void;
+  (a1: T1, cb: CB<TResult>): void;
+  (a1: T1, a2: T2, cb: CB<TResult>): void;
+  (a1: T1, a2: T2, a3: T3, cb: CB<TResult>): void;
+  (a1: T1, a2: T2, a3: T3, a4: T4, cb: CB<TResult>): void;
+  (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, cb: CB<TResult>): void;
+  (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, cb: CB<TResult>): void;
 }
 
-interface IMemoized<T1, T2, T3, T4, T5, T6, TResult> extends ResultBase {
-  (arg1: T1, cb: INodeStyleCallBack<TResult>): void;
-  (arg1: T1, arg2: T2, cb: INodeStyleCallBack<TResult>): void;
-  (arg1: T1, arg2: T2, arg3: T3, cb: INodeStyleCallBack<TResult>): void;
-  (arg1: T1, arg2: T2, arg3: T3, arg4: T4, cb: INodeStyleCallBack<TResult>): void;
-  (
-      arg1: T1,
-      arg2: T2,
-      arg3: T3,
-      arg4: T4,
-      arg5: T5,
-      cb: INodeStyleCallBack<TResult>
-  ): void;
-  (
-      arg1: T1,
-      arg2: T2,
-      arg3: T3,
-      arg4: T4,
-      arg5: T5,
-      arg6: T6,
-      cb: INodeStyleCallBack<TResult>
-  ): void;
+interface IMemoizableFunction0<TResult> {
+  (cb: CB<TResult>): void;
 }
-
-interface IMemoizableFunction<T1, T2, T3, T4, T5, T6, TResult> {
-  (cb: INodeStyleCallBack<TResult>): void;
-  (arg1: T1, cb: INodeStyleCallBack<TResult>): void;
-  (arg1: T1, arg2: T2, cb: INodeStyleCallBack<TResult>): void;
-  (
-      arg1: T1,
-      arg2: T2,
-      arg3: T3,
-      cb: INodeStyleCallBack<TResult>
-  ): void;
-  (
-      arg1: T1,
-      arg2: T2,
-      arg3: T3,
-      arg4: T4,
-      cb: INodeStyleCallBack<TResult>
-  ): void;
-  (
-      arg1: T1,
-      arg2: T2,
-      arg3: T3,
-      arg4: T4,
-      arg5: T5,
-      cb: INodeStyleCallBack<TResult>
-  ): void;
-  (
-      arg1: T1,
-      arg2: T2,
-      arg3: T3,
-      arg4: T4,
-      arg5: T5,
-      arg6: T6,
-      cb: INodeStyleCallBack<TResult>
-  ): void;
+interface IMemoizableFunction1<T1, TResult> {
+  (a1: T1, cb: CB<TResult>): void;
+}
+interface IMemoizableFunction2<T1, T2, TResult> {
+  (a1: T1, a2: T2, cb: CB<TResult>): void;
+}
+interface IMemoizableFunction3<T1, T2, T3, TResult> {
+  (a1: T1, a2: T2, a3: T3, cb: CB<TResult>): void;
+}
+interface IMemoizableFunction4<T1, T2, T3, T4, TResult> {
+  (a1: T1, a2: T2, a3: T3, a4: T4, cb: CB<TResult>): void;
+}
+interface IMemoizableFunction5<T1, T2, T3, T4, T5, TResult> {
+  (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, cb: CB<TResult>): void;
+}
+interface IMemoizableFunction6<T1, T2, T3, T4, T5, T6, TResult> {
+  (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, cb: CB<TResult>): void;
+}
+interface IMemoizableFunctionPlus {
   (...rest: any[]): void;
 }
 
-interface AsyncParams<T1, T2, T3, T4, T5, T6, TResult> extends IParamsBase<T1, T2, T3, T4, T5, T6, TResult> {
+interface AsyncParamsPlus extends IParamsBasePlus {
+  load: IMemoizableFunctionPlus;
+}
+interface AsyncParams0<TResult> extends IParamsBase0<TResult> {
+  load: IMemoizableFunction0<TResult>;
+}
+interface AsyncParams1<T1, TResult> extends IParamsBase1<T1, TResult> {
+  load: IMemoizableFunction1<T1, TResult>;
+}
+interface AsyncParams2<T1, T2, TResult> extends IParamsBase2<T1, T2, TResult> {
+  load: IMemoizableFunction2<T1, T2, TResult>;
+}
+interface AsyncParams3<T1, T2, T3, TResult>
+  extends IParamsBase3<T1, T2, T3, TResult> {
+  load: IMemoizableFunction3<T1, T2, T3, TResult>;
+}
+interface AsyncParams4<T1, T2, T3, T4, TResult>
+  extends IParamsBase4<T1, T2, T3, T4, TResult> {
+  load: IMemoizableFunction4<T1, T2, T3, T4, TResult>;
+}
+interface AsyncParams5<T1, T2, T3, T4, T5, TResult>
+  extends IParamsBase5<T1, T2, T3, T4, T5, TResult> {
+  load: IMemoizableFunction5<T1, T2, T3, T4, T5, TResult>;
+}
+interface AsyncParams6<T1, T2, T3, T4, T5, T6, TResult>
+  extends IParamsBase6<T1, T2, T3, T4, T5, T6, TResult> {
   /**
    * The function that loads the resource when is not in the cache.
    */
-  load: IMemoizableFunction<T1, T2, T3, T4, T5, T6, TResult>;
+  load: IMemoizableFunction6<T1, T2, T3, T4, T5, T6, TResult>;
 }
 
+function asyncMemoizer<TResult>(
+  options: AsyncParams0<TResult>
+): IMemoized<unknown, unknown, unknown, unknown, unknown, unknown, TResult>;
+function asyncMemoizer<T1, TResult>(
+  options: AsyncParams1<T1, TResult>
+): IMemoized<T1, unknown, unknown, unknown, unknown, unknown, TResult>;
+function asyncMemoizer<T1, T2, TResult>(
+  options: AsyncParams2<T1, T2, TResult>
+): IMemoized<T1, T2, unknown, unknown, unknown, unknown, TResult>;
+function asyncMemoizer<T1, T2, T3, TResult>(
+  options: AsyncParams3<T1, T2, T3, TResult>
+): IMemoized<T1, T2, T3, unknown, unknown, unknown, TResult>;
+function asyncMemoizer<T1, T2, T3, T4, TResult>(
+  options: AsyncParams4<T1, T2, T3, T4, TResult>
+): IMemoized<T1, T2, T3, T4, unknown, unknown, TResult>;
+function asyncMemoizer<T1, T2, T3, T4, T5, TResult>(
+  options: AsyncParams5<T1, T2, T3, T4, T5, TResult>
+): IMemoized<T1, T2, T3, T4, T5, unknown, TResult>;
 function asyncMemoizer<T1, T2, T3, T4, T5, T6, TResult>(
-    options: AsyncParams<T1, T2, T3, T4, T5, T6, TResult>
-) : IMemoized<T1, T2, T3, T4, T5, T6, TResult> {
+  options: AsyncParams6<T1, T2, T3, T4, T5, T6, TResult>
+): IMemoized<T1, T2, T3, T4, T5, T6, TResult>;
+function asyncMemoizer<T1, T2, T3, T4, T5, T6, TResult>(
+  options: AsyncParamsPlus
+): IMemoized<T1, T2, T3, T4, T5, T6, TResult> {
   const cache      = new LRU(options);
   const load       = options.load;
   const hash       = options.hash;

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -2,65 +2,105 @@ import LRU from 'lru-cache';
 import { EventEmitter } from 'events';
 import deepClone from 'lodash.clonedeep';
 import { deepFreeze } from './freeze';
-import { ResultBase, IParamsBase} from './util';
+import {
+  ResultBase,
+  IParamsBase0,
+  IParamsBase1,
+  IParamsBase2,
+  IParamsBase3,
+  IParamsBase4,
+  IParamsBase5,
+  IParamsBase6,
+  IParamsBasePlus,
+} from './util';
 
 interface IMemoizedSync<T1, T2, T3, T4, T5, T6, TResult> extends ResultBase {
   (arg1: T1): TResult;
   (arg1: T1, arg2: T2): TResult;
   (arg1: T1, arg2: T2, arg3: T3): TResult;
   (arg1: T1, arg2: T2, arg3: T3, arg4: T4): TResult;
-  (
-      arg1: T1,
-      arg2: T2,
-      arg3: T3,
-      arg4: T4,
-      arg5: T5
-  ): TResult;
-  (
-      arg1: T1,
-      arg2: T2,
-      arg3: T3,
-      arg4: T4,
-      arg5: T5,
-      arg6: T6
-  ): TResult;
+  (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5): TResult;
+  (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6): TResult;
 }
 
-
-interface IMemoizableFunctionSync<T1, T2, T3, T4, T5, T6, TResult> {
+interface IMemoizableFunctionSync0<TResult> {
   (): TResult;
+}
+interface IMemoizableFunctionSync1<T1, TResult> {
   (arg1: T1): TResult;
+}
+interface IMemoizableFunctionSync2<T1, T2, TResult> {
   (arg1: T1, arg2: T2): TResult;
+}
+interface IMemoizableFunctionSync3<T1, T2, T3, TResult> {
   (arg1: T1, arg2: T2, arg3: T3): TResult;
+}
+interface IMemoizableFunctionSync4<T1, T2, T3, T4, TResult> {
   (arg1: T1, arg2: T2, arg3: T3, arg4: T4): TResult;
-  (
-      arg1: T1,
-      arg2: T2,
-      arg3: T3,
-      arg4: T4,
-      arg5: T5
-  ): TResult;
-  (
-      arg1: T1,
-      arg2: T2,
-      arg3: T3,
-      arg4: T4,
-      arg5: T5,
-      arg6: T6
-  ): TResult;
-  ( ...args: any[] ): TResult;
+}
+interface IMemoizableFunctionSync5<T1, T2, T3, T4, T5, TResult> {
+  (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5): TResult;
+}
+interface IMemoizableFunctionSync6<T1, T2, T3, T4, T5, T6, TResult> {
+  (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6): TResult;
+}
+interface IMemoizableFunctionSyncPlus<TResult> {
+  (...args: any[]): TResult;
 }
 
-export interface SyncParams<T1, T2, T3, T4, T5, T6, TResult> extends IParamsBase<T1, T2, T3, T4, T5, T6, TResult> {
-  /**
-   * The function that loads the resource when is not in the cache.
-   */
-  load: IMemoizableFunctionSync<T1, T2, T3, T4, T5, T6, TResult>;
+export interface SyncParams0<TResult> extends IParamsBase0<TResult> {
+  load: IMemoizableFunctionSync0<TResult>;
 }
-
+export interface SyncParams1<T1, TResult> extends IParamsBase1<T1, TResult> {
+  load: IMemoizableFunctionSync1<T1, TResult>;
+}
+export interface SyncParams2<T1, T2, TResult>
+  extends IParamsBase2<T1, T2, TResult> {
+  load: IMemoizableFunctionSync2<T1, T2, TResult>;
+}
+export interface SyncParams3<T1, T2, T3, TResult>
+  extends IParamsBase3<T1, T2, T3, TResult> {
+  load: IMemoizableFunctionSync3<T1, T2, T3, TResult>;
+}
+export interface SyncParams4<T1, T2, T3, T4, TResult>
+  extends IParamsBase4<T1, T2, T3, T4, TResult> {
+  load: IMemoizableFunctionSync4<T1, T2, T3, T4, TResult>;
+}
+export interface SyncParams5<T1, T2, T3, T4, T5, TResult>
+  extends IParamsBase5<T1, T2, T3, T4, T5, TResult> {
+  load: IMemoizableFunctionSync5<T1, T2, T3, T4, T5, TResult>;
+}
+export interface SyncParams6<T1, T2, T3, T4, T5, T6, TResult>
+  extends IParamsBase6<T1, T2, T3, T4, T5, T6, TResult> {
+  load: IMemoizableFunctionSync6<T1, T2, T3, T4, T5, T6, TResult>;
+}
+export interface SyncParamsPlus<TResult> extends IParamsBasePlus {
+  load: IMemoizableFunctionSyncPlus<TResult>;
+}
+export function syncMemoizer<TResult>(
+  options: SyncParams0<TResult>
+): IMemoizedSync<unknown, unknown, unknown, unknown, unknown, unknown, TResult>;
+export function syncMemoizer<T1, TResult>(
+  options: SyncParams1<T1, TResult>
+): IMemoizedSync<T1, unknown, unknown, unknown, unknown, unknown, TResult>;
+export function syncMemoizer<T1, T2, TResult>(
+  options: SyncParams2<T1, T2, TResult>
+): IMemoizedSync<T1, T2, unknown, unknown, unknown, unknown, TResult>;
+export function syncMemoizer<T1, T2, T3, TResult>(
+  options: SyncParams3<T1, T2, T3, TResult>
+): IMemoizedSync<T1, T2, T3, unknown, unknown, unknown, TResult>;
+export function syncMemoizer<T1, T2, T3, T4, TResult>(
+  options: SyncParams4<T1, T2, T3, T4, TResult>
+): IMemoizedSync<T1, T2, T3, T4, unknown, unknown, TResult>;
+export function syncMemoizer<T1, T2, T3, T4, T5, TResult>(
+  options: SyncParams5<T1, T2, T3, T4, T5, TResult>
+): IMemoizedSync<T1, T2, T3, T4, T5, unknown, TResult>;
 export function syncMemoizer<T1, T2, T3, T4, T5, T6, TResult>(
-    options: SyncParams<T1, T2, T3, T4, T5, T6, TResult>
-) : IMemoizedSync<T1, T2, T3, T4, T5, T6, TResult> {
+  options: SyncParams6<T1, T2, T3, T4, T5, T6, TResult>
+): IMemoizedSync<T1, T2, T3, T4, T5, T6, TResult>;
+export function syncMemoizer<T1, T2, T3, T4, T5, T6, TResult>(
+  options: SyncParamsPlus<TResult>
+): IMemoizedSync<T1, T2, T3, T4, T5, T6, TResult> {
   const cache      = new LRU(options);
   const load       = options.load;
   const hash       = options.hash;
@@ -75,7 +115,7 @@ export function syncMemoizer<T1, T2, T3, T4, T5, T6, TResult>(
     reset: () => cache.reset(),
     keys: cache.keys.bind(cache),
     on: emitter.on.bind(emitter),
-    once: emitter.once.bind(emitter)
+    once: emitter.once.bind(emitter),
   }, options);
 
   if (options.disable) {
@@ -118,10 +158,9 @@ export function syncMemoizer<T1, T2, T3, T4, T5, T6, TResult>(
     return res;
   }
 
-  const result : IMemoizableFunctionSync<T1, T2, T3, T4, T5, T6, TResult> = function (
+  const result: IMemoizableFunctionSync6<T1, T2, T3, T4, T5, T6, TResult> = function (
     ...args: any[]
   ) {
-
     if (bypass && bypass(...args)) {
       emit('miss', ...args);
       return load(...args);
@@ -150,5 +189,5 @@ export function syncMemoizer<T1, T2, T3, T4, T5, T6, TResult>(
     return processResult(result);
   };
 
-  return Object.assign(result, defaultResult);
+  return Object.assign(result, defaultResult) as any;
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,9 @@
 import LRU from 'lru-cache';
-export type Listener = (...args: any[]) => void;
-export type INodeStyleCallBack<SuccessArg> = (err: Error, result?: SuccessArg) => void;
+export type Listener = (...as: any[]) => void;
+export type INodeStyleCallBack<Success> = (
+  err: Error | null,
+  result?: Success
+) => void;
 
 export interface ResultBase {
   /**
@@ -16,115 +19,149 @@ export interface ResultBase {
   /**
    * Delete an item given the parameters.
    */
-  del: <T1, T2, T3, T4, T5, T6>(arg1: T1,arg2: T2,arg3: T3,arg4: T4,arg5: T5,arg6: T6) => void
+  del: <T1, T2, T3, T4, T5, T6>(
+    a1?: T1,
+    a2?: T2,
+    a3?: T3,
+    a4?: T4,
+    a5?: T5,
+    a6?: T6
+  ) => void;
   on(event: 'hit', handler: Listener): void;
   on(event: 'miss', handler: Listener): void;
   on(event: 'queue', handler: Listener): void;
 }
 
-export interface IHashingFunction<T1, T2, T3, T4, T5, T6> {
+export interface IHashingFunction0 {
   (): string;
-  (arg1: T1): string;
-  (arg1: T1, arg2: T2): string;
-  (arg1: T1, arg2: T2, arg3: T3): string;
-  (arg1: T1, arg2: T2, arg3: T3, arg4: T4): string;
-  (
-      arg1: T1,
-      arg2: T2,
-      arg3: T3,
-      arg4: T4,
-      arg5: T5
-  ): string;
-  (
-      arg1: T1,
-      arg2: T2,
-      arg3: T3,
-      arg4: T4,
-      arg5: T5,
-      arg6: T6
-  ): string;
-  (
-      arg1: T1,
-      arg2: T2,
-      arg3: T3,
-      arg4: T4,
-      arg5: T5,
-      arg6: T6,
-  ): string;
-  (
-    ...rest: any[]
-  ): string;
+}
+export interface IHashingFunction1<T1> {
+  (a1: T1): string;
+}
+export interface IHashingFunction2<T1, T2> {
+  (a1: T1, a2: T2): string;
+}
+export interface IHashingFunction3<T1, T2, T3> {
+  (a1: T1, a2: T2, a3: T3): string;
+}
+export interface IHashingFunction4<T1, T2, T3, T4> {
+  (a1: T1, a2: T2, a3: T3, a4: T4): string;
+}
+export interface IHashingFunction5<T1, T2, T3, T4, T5> {
+  (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5): string;
+}
+export interface IHashingFunction6<T1, T2, T3, T4, T5, T6> {
+  (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6): string;
+}
+export interface IHashingFunctionPlus<> {
+  (...rest: any[]): string;
 }
 
-export interface IBypassFunction<T1, T2, T3, T4, T5, T6> {
+export interface IBypassFunction0 {
   (): boolean;
-  (arg1: T1): boolean;
-  (arg1: T1, arg2: T2): boolean;
-  (arg1: T1, arg2: T2, arg3: T3): boolean;
-  (arg1: T1, arg2: T2, arg3: T3, arg4: T4): boolean;
-  (
-      arg1: T1,
-      arg2: T2,
-      arg3: T3,
-      arg4: T4,
-      arg5: T5
-  ): boolean;
-  (
-      arg1: T1,
-      arg2: T2,
-      arg3: T3,
-      arg4: T4,
-      arg5: T5,
-      arg6: T6
-  ): boolean;
-  (
-    ...rest: any[]
-  ): boolean;
+}
+export interface IBypassFunction1<T1> {
+  (a1: T1): boolean;
+}
+export interface IBypassFunction2<T1, T2> {
+  (a1: T1, a2: T2): boolean;
+}
+export interface IBypassFunction3<T1, T2, T3> {
+  (a1: T1, a2: T2, a3: T3): boolean;
+}
+export interface IBypassFunction4<T1, T2, T3, T4> {
+  (a1: T1, a2: T2, a3: T3, a4: T4): boolean;
+}
+export interface IBypassFunction5<T1, T2, T3, T4, T5> {
+  (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5): boolean;
+}
+export interface IBypassFunction6<T1, T2, T3, T4, T5, T6> {
+  (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6): boolean;
+}
+export interface IBypassFunctionPlus {
+  (...rest: any[]): boolean;
 }
 
-export interface IMaxAgeFunction<T1, T2, T3, T4, T5, T6, TResult> {
+export interface IMaxAgeFunction0<TResult> {
   (res: TResult): number;
-  (arg1: T1, res: TResult): number;
-  (arg1: T1, arg2: T2, res: TResult): number;
-  (arg1: T1, arg2: T2, arg3: T3, res: TResult): number;
-  (arg1: T1, arg2: T2, arg3: T3, arg4: T4, res: TResult): number;
-  (
-      arg1: T1,
-      arg2: T2,
-      arg3: T3,
-      arg4: T4,
-      arg5: T5,
-      res: TResult): number;
-  (
-      arg1: T1,
-      arg2: T2,
-      arg3: T3,
-      arg4: T4,
-      arg5: T5,
-      arg6: T6,
-      res: TResult): number;
-  (
-    ...rest: any[]
-  ): number;
+}
+export interface IMaxAgeFunction1<T1, TResult> {
+  (a1: T1, res: TResult): number;
+}
+export interface IMaxAgeFunction2<T1, T2, TResult> {
+  (a1: T1, a2: T2, res: TResult): number;
+}
+export interface IMaxAgeFunction3<T1, T2, T3, TResult> {
+  (a1: T1, a2: T2, a3: T3, res: TResult): number;
+}
+export interface IMaxAgeFunction4<T1, T2, T3, T4, TResult> {
+  (a1: T1, a2: T2, a3: T3, a4: T4, res: TResult): number;
+}
+export interface IMaxAgeFunction5<T1, T2, T3, T4, T5, TResult> {
+  (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, res: TResult): number;
+}
+export interface IMaxAgeFunction6<T1, T2, T3, T4, T5, T6, TResult> {
+  (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, res: TResult): number;
+}
+export interface IMaxAgeFunctionPlus {
+  (...rest: any[]): number;
 }
 
-export interface IParamsBase<T1, T2, T3, T4, T5, T6, TResult> extends LRU.Options<string, any>  {
-
+export interface IParamsBase0<TResult> extends IParamsBaseCommons {
+  hash: IHashingFunction0;
+  bypass?: IBypassFunction0;
+  itemMaxAge?: IMaxAgeFunction0<TResult>;
+}
+export interface IParamsBase1<T1, TResult> extends IParamsBaseCommons {
+  hash: IHashingFunction1<T1>;
+  bypass?: IBypassFunction1<T1>;
+  itemMaxAge?: IMaxAgeFunction1<T1, TResult>;
+}
+export interface IParamsBase2<T1, T2, TResult> extends IParamsBaseCommons {
+  hash: IHashingFunction2<T1, T2>;
+  bypass?: IBypassFunction2<T1, T2>;
+  itemMaxAge?: IMaxAgeFunction2<T1, T2, TResult>;
+}
+export interface IParamsBase3<T1, T2, T3, TResult> extends IParamsBaseCommons {
+  hash: IHashingFunction3<T1, T2, T3>;
+  bypass?: IBypassFunction3<T1, T2, T3>;
+  itemMaxAge?: IMaxAgeFunction3<T1, T2, T3, TResult>;
+}
+export interface IParamsBase4<T1, T2, T3, T4, TResult>
+  extends IParamsBaseCommons {
+  hash: IHashingFunction4<T1, T2, T3, T4>;
+  bypass?: IBypassFunction4<T1, T2, T3, T4>;
+  itemMaxAge?: IMaxAgeFunction4<T1, T2, T3, T4, TResult>;
+}
+export interface IParamsBase5<T1, T2, T3, T4, T5, TResult>
+  extends IParamsBaseCommons {
+  hash: IHashingFunction5<T1, T2, T3, T4, T5>;
+  bypass?: IBypassFunction5<T1, T2, T3, T4, T5>;
+  itemMaxAge?: IMaxAgeFunction5<T1, T2, T3, T4, T5, TResult>;
+}
+export interface IParamsBase6<T1, T2, T3, T4, T5, T6, TResult>
+  extends IParamsBaseCommons {
   /**
    * A function to generate the key of the cache.
    */
-  hash: IHashingFunction<T1, T2, T3, T4, T5, T6>;
+  hash: IHashingFunction6<T1, T2, T3, T4, T5, T6>;
 
   /**
    * Return true if the result should not be retrieved from the cache.
    */
-  bypass?: IBypassFunction<T1, T2, T3, T4, T5, T6>;
+  bypass?: IBypassFunction6<T1, T2, T3, T4, T5, T6>;
 
   /**
    * An optional function to indicate the maxAge of an specific item.
    */
-  itemMaxAge: IMaxAgeFunction<T1, T2, T3, T4, T5, T6, TResult>;
-
+  itemMaxAge?: IMaxAgeFunction6<T1, T2, T3, T4, T5, T6, TResult>;
+}
+export interface IParamsBasePlus extends IParamsBaseCommons {
+  hash: IHashingFunctionPlus;
+  bypass?: IBypassFunctionPlus;
+  itemMaxAge?: IMaxAgeFunctionPlus;
+}
+interface IParamsBaseCommons extends LRU.Options<string, any> {
   /**
    * Indicates if the resource should be freezed.
    */


### PR DESCRIPTION
Hi there!

As far as I can tell, the types enclosed in this library are not so easy to use in practice.
This is an attempt at making them a little bit easier to use on a day to day basis.

I focused mainly on the options when calling `memoize` (sync or async) to that types aligns somewhat in `load`, `hash` and `itemMaxAge`.
The return type from `memoize` is still not very practical, but baby steps :)