### PR TITLE
update lru cache and typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,16 +10,15 @@
       "license": "MIT",
       "dependencies": {
         "lodash.clonedeep": "^4.5.0",
-        "lru-cache": "6.0.0"
+        "lru-cache": "^11.0.1"
       },
       "devDependencies": {
         "@types/lodash.clonedeep": "^4.5.9",
-        "@types/lru-cache": "^5.1.0",
         "@types/node": "^12.0.10",
         "chai": "^3.5.0",
         "mocha": "^10.4.0",
         "sinon": "^7.3.2",
-        "typescript": "^3.5.2"
+        "typescript": "^4.9.5"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -81,12 +80,6 @@
       "dependencies": {
         "@types/lodash": "*"
       }
-    },
-    "node_modules/@types/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==",
-      "dev": true
     },
     "node_modules/@types/node": {
       "version": "12.20.55",
@@ -681,14 +674,11 @@
       "dev": true
     },
     "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.1.tgz",
+      "integrity": "sha512-CgeuL5uom6j/ZVrg7G/+1IXqRY8JXX4Hghfy5YE0EhoYQWvndP1kufu58cmZLNIDKnRhZrXfdS9urVWx98AipQ==",
       "engines": {
-        "node": ">=10"
+        "node": "20 || >=22"
       }
     },
     "node_modules/minimatch": {
@@ -1023,9 +1013,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -1072,11 +1062,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -19,16 +19,15 @@
   },
   "dependencies": {
     "lodash.clonedeep": "^4.5.0",
-    "lru-cache": "6.0.0"
+    "lru-cache": "^11.0.1"
   },
   "license": "MIT",
   "devDependencies": {
     "@types/lodash.clonedeep": "^4.5.9",
-    "@types/lru-cache": "^5.1.0",
     "@types/node": "^12.0.10",
     "chai": "^3.5.0",
     "mocha": "^10.4.0",
     "sinon": "^7.3.2",
-    "typescript": "^3.5.2"
+    "typescript": "^4.9.5"
   }
 }

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1,4 +1,4 @@
-import LRU from 'lru-cache';
+import { LRUCache } from 'lru-cache';
 import { EventEmitter } from 'events';
 import deepClone from 'lodash.clonedeep';
 import { deepFreeze } from './freeze';
@@ -48,33 +48,33 @@ interface IMemoizableFunctionSyncPlus<TResult> {
   (...args: any[]): TResult;
 }
 
-export interface SyncParams0<TResult> extends IParamsBase0<TResult> {
+export type SyncParams0<TResult> = IParamsBase0<TResult> & {
   load: IMemoizableFunctionSync0<TResult>;
 }
-export interface SyncParams1<T1, TResult> extends IParamsBase1<T1, TResult> {
+export type SyncParams1<T1, TResult> = IParamsBase1<T1, TResult> & {
   load: IMemoizableFunctionSync1<T1, TResult>;
 }
-export interface SyncParams2<T1, T2, TResult>
-  extends IParamsBase2<T1, T2, TResult> {
+export type SyncParams2<T1, T2, TResult>
+  = IParamsBase2<T1, T2, TResult> & {
   load: IMemoizableFunctionSync2<T1, T2, TResult>;
 }
-export interface SyncParams3<T1, T2, T3, TResult>
-  extends IParamsBase3<T1, T2, T3, TResult> {
+export type SyncParams3<T1, T2, T3, TResult>
+  = IParamsBase3<T1, T2, T3, TResult> & {
   load: IMemoizableFunctionSync3<T1, T2, T3, TResult>;
 }
-export interface SyncParams4<T1, T2, T3, T4, TResult>
-  extends IParamsBase4<T1, T2, T3, T4, TResult> {
+export type SyncParams4<T1, T2, T3, T4, TResult>
+  = IParamsBase4<T1, T2, T3, T4, TResult> & {
   load: IMemoizableFunctionSync4<T1, T2, T3, T4, TResult>;
 }
-export interface SyncParams5<T1, T2, T3, T4, T5, TResult>
-  extends IParamsBase5<T1, T2, T3, T4, T5, TResult> {
+export type SyncParams5<T1, T2, T3, T4, T5, TResult>
+  = IParamsBase5<T1, T2, T3, T4, T5, TResult> & {
   load: IMemoizableFunctionSync5<T1, T2, T3, T4, T5, TResult>;
 }
-export interface SyncParams6<T1, T2, T3, T4, T5, T6, TResult>
-  extends IParamsBase6<T1, T2, T3, T4, T5, T6, TResult> {
+export type SyncParams6<T1, T2, T3, T4, T5, T6, TResult>
+  = IParamsBase6<T1, T2, T3, T4, T5, T6, TResult>  & {
   load: IMemoizableFunctionSync6<T1, T2, T3, T4, T5, T6, TResult>;
 }
-export interface SyncParamsPlus<TResult> extends IParamsBasePlus {
+export type SyncParamsPlus<TResult> = IParamsBasePlus & {
   load: IMemoizableFunctionSyncPlus<TResult>;
 }
 export function syncMemoizer<TResult>(
@@ -101,7 +101,7 @@ export function syncMemoizer<T1, T2, T3, T4, T5, T6, TResult>(
 export function syncMemoizer<T1, T2, T3, T4, T5, T6, TResult>(
   options: SyncParamsPlus<TResult>
 ): IMemoizedSync<T1, T2, T3, T4, T5, T6, TResult> {
-  const cache      = new LRU(options);
+  const cache      = new LRUCache(options);
   const load       = options.load;
   const hash       = options.hash;
   const bypass     = options.bypass;
@@ -112,8 +112,8 @@ export function syncMemoizer<T1, T2, T3, T4, T5, T6, TResult>(
 
   const defaultResult = Object.assign({
     del,
-    reset: () => cache.reset(),
-    keys: cache.keys.bind(cache),
+    reset: () => cache.clear(),
+    keys: () => [...cache.keys()],
     on: emitter.on.bind(emitter),
     once: emitter.once.bind(emitter),
   }, options);
@@ -124,7 +124,7 @@ export function syncMemoizer<T1, T2, T3, T4, T5, T6, TResult>(
 
   function del() {
     const key = hash(...arguments);
-    cache.del(key);
+    cache.delete(key);
   }
 
   function emit(event: string, ...parameters: any[]) {
@@ -181,7 +181,7 @@ export function syncMemoizer<T1, T2, T3, T4, T5, T6, TResult>(
 
     if (itemMaxAge) {
       // @ts-ignore
-      cache.set(key, result, itemMaxAge(...args.concat([ result ])));
+      cache.set(key, result, {ttl: itemMaxAge(...args.concat([ result ]))});
     } else {
       cache.set(key, result);
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,4 @@
-import LRU from 'lru-cache';
+import { LRUCache } from 'lru-cache';
 export type Listener = (...as: any[]) => void;
 export type INodeStyleCallBack<Success> = (
   err: Error | null,
@@ -107,40 +107,40 @@ export interface IMaxAgeFunctionPlus {
   (...rest: any[]): number;
 }
 
-export interface IParamsBase0<TResult> extends IParamsBaseCommons {
+export type IParamsBase0<TResult> = IParamsBaseCommons & {
   hash: IHashingFunction0;
   bypass?: IBypassFunction0;
   itemMaxAge?: IMaxAgeFunction0<TResult>;
 }
-export interface IParamsBase1<T1, TResult> extends IParamsBaseCommons {
+export type IParamsBase1<T1, TResult> = IParamsBaseCommons & {
   hash: IHashingFunction1<T1>;
   bypass?: IBypassFunction1<T1>;
   itemMaxAge?: IMaxAgeFunction1<T1, TResult>;
 }
-export interface IParamsBase2<T1, T2, TResult> extends IParamsBaseCommons {
+export type IParamsBase2<T1, T2, TResult> = IParamsBaseCommons & {
   hash: IHashingFunction2<T1, T2>;
   bypass?: IBypassFunction2<T1, T2>;
   itemMaxAge?: IMaxAgeFunction2<T1, T2, TResult>;
 }
-export interface IParamsBase3<T1, T2, T3, TResult> extends IParamsBaseCommons {
+export type IParamsBase3<T1, T2, T3, TResult> = IParamsBaseCommons & {
   hash: IHashingFunction3<T1, T2, T3>;
   bypass?: IBypassFunction3<T1, T2, T3>;
   itemMaxAge?: IMaxAgeFunction3<T1, T2, T3, TResult>;
 }
-export interface IParamsBase4<T1, T2, T3, T4, TResult>
-  extends IParamsBaseCommons {
+export type IParamsBase4<T1, T2, T3, T4, TResult>
+  = IParamsBaseCommons & {
   hash: IHashingFunction4<T1, T2, T3, T4>;
   bypass?: IBypassFunction4<T1, T2, T3, T4>;
   itemMaxAge?: IMaxAgeFunction4<T1, T2, T3, T4, TResult>;
 }
-export interface IParamsBase5<T1, T2, T3, T4, T5, TResult>
-  extends IParamsBaseCommons {
+export type IParamsBase5<T1, T2, T3, T4, T5, TResult>
+  = IParamsBaseCommons & {
   hash: IHashingFunction5<T1, T2, T3, T4, T5>;
   bypass?: IBypassFunction5<T1, T2, T3, T4, T5>;
   itemMaxAge?: IMaxAgeFunction5<T1, T2, T3, T4, T5, TResult>;
 }
-export interface IParamsBase6<T1, T2, T3, T4, T5, T6, TResult>
-  extends IParamsBaseCommons {
+export type IParamsBase6<T1, T2, T3, T4, T5, T6, TResult>
+  = IParamsBaseCommons & {
   /**
    * A function to generate the key of the cache.
    */
@@ -156,12 +156,12 @@ export interface IParamsBase6<T1, T2, T3, T4, T5, T6, TResult>
    */
   itemMaxAge?: IMaxAgeFunction6<T1, T2, T3, T4, T5, T6, TResult>;
 }
-export interface IParamsBasePlus extends IParamsBaseCommons {
+export type IParamsBasePlus = IParamsBaseCommons & {
   hash: IHashingFunctionPlus;
   bypass?: IBypassFunctionPlus;
   itemMaxAge?: IMaxAgeFunctionPlus;
 }
-interface IParamsBaseCommons extends LRU.Options<string, any> {
+type IParamsBaseCommons = LRUCache.Options<string, any, unknown> & {
   /**
    * Indicates if the resource should be freezed.
    */

--- a/test/lru-memoizer.clone.test.js
+++ b/test/lru-memoizer.clone.test.js
@@ -15,7 +15,8 @@ describe('lru-memoizer (clone)', () => {
       hash: (key) => {
         return key;
       },
-      clone: true
+      clone: true,
+      max: 10
     });
   });
 

--- a/test/lru-memoizer.freeze.test.js
+++ b/test/lru-memoizer.freeze.test.js
@@ -17,6 +17,7 @@ describe("lru-memoizer (freeze)", function () {
         return key;
       },
       freeze: true,
+      max: 10
     });
   });
 

--- a/test/lru-memoizer.itemmaxage.test.js
+++ b/test/lru-memoizer.itemmaxage.test.js
@@ -20,7 +20,7 @@ describe('lru-memoizer (itemMaxAge)', function () {
         return a + '-' + b;
       },
       max: 10,
-      maxAge: 500
+      maxAge: 500,
     });
 
     memoized(1,2, function (err, result) {

--- a/test/lru-memoizer.nokey.test.js
+++ b/test/lru-memoizer.nokey.test.js
@@ -8,6 +8,7 @@ describe('lru-memoizer (no key)', function () {
     loadTimes = 0;
 
     memoized = memoizer({
+      max: 10,
       load: function (callback) {
         loadTimes++;
         return setTimeout(function () {

--- a/test/lru-memoizer.queumaxage.test.js
+++ b/test/lru-memoizer.queumaxage.test.js
@@ -29,7 +29,8 @@ describe('lru-memoizer (queueMaxAge)', function () {
       queueMaxAge: 10,
       hash: function (a, b) {
         return a + '-' + b;
-      }
+      },
+      max: 10
     });
 
     const observer1 = observer();

--- a/test/lru-memoizer.sync.clone.test.js
+++ b/test/lru-memoizer.sync.clone.test.js
@@ -17,7 +17,8 @@ describe('lru-memoizer sync (clone)', () => {
         hash: (key) => {
           return key;
         },
-        clone: true
+        clone: true,
+        max: 10
       });
     });
 
@@ -49,7 +50,8 @@ describe('lru-memoizer sync (clone)', () => {
         hash: (key) => {
           return key;
         },
-        clone: true
+        clone: true,
+        max: 10
       });
     });
 

--- a/test/lru-memoizer.sync.freeze.js
+++ b/test/lru-memoizer.sync.freeze.js
@@ -17,7 +17,8 @@ describe('lru-memoizer sync (freeze)', () => {
         hash: (key) => {
           return key;
         },
-        freeze: true
+        freeze: true,
+        max: 10
       });
     });
 
@@ -48,7 +49,8 @@ describe('lru-memoizer sync (freeze)', () => {
         hash: (key) => {
           return key;
         },
-        freeze: true
+        freeze: true,
+        max: 10
       });
     });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,59 +1,19 @@
 {
   "compilerOptions": {
-    /* Basic Options */
-    "target": "ES5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
-    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    "lib": ["es2015", "es2017"],                             /* Specify library files to be included in the compilation. */
-    // "allowJs": true,                       /* Allow javascript files to be compiled. */
-    // "checkJs": true,                       /* Report errors in .js files. */
-    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    "declaration": true,                   /* Generates corresponding '.d.ts' file. */
-    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
-    // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    "outDir": "./lib",                        /* Redirect output structure to the directory. */
-    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-    // "composite": true,                     /* Enable project compilation */
-    // "removeComments": true,                /* Do not emit comments to output. */
-    // "noEmit": true,                        /* Do not emit outputs. */
-    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
-    "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
-    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
-
-    /* Strict Type-Checking Options */
-    "strict": true,                           /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
-    "strictNullChecks": false,              /* Enable strict null checks. */
-    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
-    // "strictPropertyInitialization": false,  /* Enable strict checking of property initialization in classes. */
-    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
-    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
-
-    /* Additional Checks */
-    // "noUnusedLocals": true,                /* Report errors on unused locals. */
-    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
-    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
-    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
-
-    /* Module Resolution Options */
-    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
-    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                       /* List of folders to include type definitions from. */
-    // "types": [],                           /* Type declaration files to be included in compilation. */
-    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true,                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
-    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
-
-    /* Source Map Options */
-    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
-    "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
-    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-
-    /* Experimental Options */
-    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
-    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "inlineSources": true,
+    "jsx": "react",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "noUncheckedIndexedAccess": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "target": "es2022",
+    "outDir": "./lib"
   }
 }


### PR DESCRIPTION
Solves https://github.com/jfromaniello/lru-memoizer/issues/32

I had to change some interfaces to types because interfaces cannot inherit from variable types and update Typescript.

The test checking the default behavior is failing because it probably has changed. I would need some help here @jfromaniello 

Thanks.